### PR TITLE
🐛 Fix command with wrong --id=value issue

### DIFF
--- a/src/Console/Commands/CreateReviewAppCommand.php
+++ b/src/Console/Commands/CreateReviewAppCommand.php
@@ -31,7 +31,7 @@ class CreateReviewAppCommand extends ForgeAbstractCommand
      * @return int
      * @throws \Exception
      */
-    public function handle()
+    public function handle(): int
     {
         parent::handle();
 

--- a/src/Console/Commands/DeployScriptCommand.php
+++ b/src/Console/Commands/DeployScriptCommand.php
@@ -25,7 +25,7 @@ class DeployScriptCommand extends ForgeAbstractCommand
      *
      * @return int
      */
-    public function handle()
+    public function handle(): int
     {
         parent::handle();
 

--- a/src/Console/Commands/DestroyCommand.php
+++ b/src/Console/Commands/DestroyCommand.php
@@ -19,7 +19,7 @@ class DestroyCommand extends ForgeAbstractCommand
      *
      * @return int
      */
-    public function handle()
+    public function handle(): int
     {
         parent::handle();
 

--- a/src/Console/Commands/EnvCommand.php
+++ b/src/Console/Commands/EnvCommand.php
@@ -23,7 +23,7 @@ class EnvCommand extends ForgeAbstractCommand
      *
      * @return int
      */
-    public function handle()
+    public function handle(): int
     {
         parent::handle();
 

--- a/src/Console/Commands/ForgeAbstractCommand.php
+++ b/src/Console/Commands/ForgeAbstractCommand.php
@@ -12,21 +12,20 @@ abstract class ForgeAbstractCommand extends Command
 {
     use CheckConfig;
 
-    /** @var ForgeServiceContract */
-    protected $forgeService;
+    protected ForgeServiceContract $forgeService;
 
-    /** @var Server */
-    protected $forgeServer;
+    protected Server $forgeServer;
 
-    public function handle()
+    public function handle(): int
     {
         $this->checkConfig('radis.forge.token');
         $this->checkConfig('radis.forge.server_name');
         $this->checkConfig('radis.forge.server_domain');
 
-        /** @var ForgeServiceContract forgeService */
         $this->forgeService = app(ForgeServiceContract::class);
         $this->forgeServer = $this->forgeService->getForgeServer();
+
+        return 0;
     }
 
     /**
@@ -37,7 +36,11 @@ abstract class ForgeAbstractCommand extends Command
     protected function getSite(string $siteName, ?int $siteId): ?Site
     {
         if (! empty($siteId) && is_int($siteId)) {
-            return $this->getSiteById($siteId);
+            $site = $this->getSiteById($siteId);
+
+            if (is_null($site) && ! $this->confirm('Would you like to try site name instead site ID ?')) {
+                return null;
+            }
         }
 
         return $this->getSiteByName($siteName);
@@ -54,9 +57,8 @@ abstract class ForgeAbstractCommand extends Command
         } catch (\Exception $e) {
             report($e);
             $this->error('No site found with this ID : ' . $siteId);
-            if (! $this->confirm('Would you like to try site name instead site ID ?')) {
-                return null;
-            }
+        } finally {
+            return null;
         }
     }
 

--- a/src/Console/Commands/UpdateCommand.php
+++ b/src/Console/Commands/UpdateCommand.php
@@ -17,7 +17,7 @@ class UpdateCommand extends ForgeAbstractCommand
      *
      * @return int
      */
-    public function handle()
+    public function handle(): int
     {
         parent::handle();
 


### PR DESCRIPTION
### Cette MR fixe le problème suivant : 

Quand je lançais cette commande par exemple : 
```
$ php artisan radis:env monsite --site={id inexistant}
  Would you like to try site name instead site ID ? (yes/no) [no]:
  > yes
```
j'avais l'erreur suivante : 

> Return value of WebId\Radis\Console\Commands\ForgeAbstractCommand::getSiteByid() must be an instance of Laravel\Forge\Resources\Site or null, none returned